### PR TITLE
fix: remove redundant autoload.files to prevent double-load fatal

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,7 @@
     "autoload": {
         "psr-4": {
             "Kamva\\Crud\\": "src/"
-        },
-        "files": [
-            "src/helpers.php"
-        ]
+        }
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
## Problem

Codex flagged this on a downstream MR ([owl!19](https://gitlab.com/hestud.io/pakat/owl/-/merge_requests/19) review):

> /private/tmp/owl-mr19-review/composer.lock:2321 updates kamva/laravel-crud to autoload src/helpers.php via Composer. That package's service provider also includes the same helpers file during boot, so the app fatals with Cannot redeclare function makeField().

The current package loads `src/helpers.php` from **two** places:

1. Composer's `autoload.files` (this file's `composer.json`, added in commit a939bf2 / aaf7cd8)
2. `KamvaCRUDServiceProvider::boot()` via `include __DIR__ . "/helpers.php"`

Today the service provider guards with `if (!function_exists('makeField'))`, so a properly synced install is safe. **But:** downstream consumers whose `vendor/` is stale relative to `composer.lock` can end up with the new `autoload.files` entry registered while still running the old service provider code (no guard). When Composer's autoload registers `helpers.php` and then the old provider's bare `include` re-runs it, PHP fatals with `Cannot redeclare function makeField()`.

## Fix

Remove the redundant `autoload.files` entry. The helper is now loaded exactly once — by the service provider's already-guarded `boot()`.

```diff
     "autoload": {
         "psr-4": {
             "Kamva\\Crud\\": "src/"
-        },
-        "files": [
-            "src/helpers.php"
         ]
     },
```

## Backwards compatibility

- Apps that consume `makeField()` from controllers' `setup()` methods are unaffected (service provider boots before any controller action).
- Apps that consume `makeField()` from CLI commands / queue workers are unaffected (service provider boots in CLI too).
- The only behavioral change: `makeField()` is no longer available **before** the framework boots service providers. No realistic consumer needs that ordering.

## Tests

`composer test` — 61 unit tests, 122 assertions, all pass. No test relied on the autoload.files entry.