### PR TITLE
Add dark mode support for package views

### DIFF
--- a/src/Service.php
+++ b/src/Service.php
@@ -32,6 +32,22 @@ class Service
         $this->set('default_acl_method', $callable);
     }
 
+    /**
+     * Set the dark mode preference for package views.
+     * 'auto'  — follows the OS/browser prefers-color-scheme media query (default).
+     * 'dark'  — always dark, regardless of system setting.
+     * 'light' — always light, regardless of system setting.
+     */
+    public function setDarkMode(string $mode = 'auto'): void
+    {
+        $this->set('dark_mode', $mode);
+    }
+
+    public function getDarkMode(): string
+    {
+        return $this->get('dark_mode') ?? 'auto';
+    }
+
     public function callColumnType($name, ...$parameters)
     {
         $callback = $this->columnHelpers[$name] ?? null;

--- a/src/views/_dark_mode.blade.php
+++ b/src/views/_dark_mode.blade.php
@@ -1,0 +1,83 @@
+@php
+    $kcDark = \Kamva\Crud\KamvaCrud::getDarkMode(); // 'auto' | 'dark' | 'light'
+    $kcAttr = $kcDark !== 'auto' ? ' data-kc-dark="' . e($kcDark) . '"' : '';
+@endphp
+{{-- Dark-mode CSS for kamva-crud package elements.
+     Wrap the view's root element with class="kamva-crud-wrap" and
+     optionally data-kc-dark="dark|light" (omit for system auto). --}}
+<style>
+    .kamva-crud-wrap {
+        --kc-bg:          #ffffff;
+        --kc-surface:     #f4f5f7;
+        --kc-card-bg:     #ffffff;
+        --kc-card-border: rgba(0, 0, 0, 0.08);
+        --kc-text:        #212529;
+        --kc-text-muted:  #718096;
+        --kc-header-bg:   #f8f9fa;
+        --kc-link:        inherit;
+    }
+
+    @media (prefers-color-scheme: dark) {
+        .kamva-crud-wrap:not([data-kc-dark="light"]) {
+            --kc-bg:          #0f0f1a;
+            --kc-surface:     #1c1c2e;
+            --kc-card-bg:     #1e1e30;
+            --kc-card-border: rgba(255, 255, 255, 0.08);
+            --kc-text:        #e2e8f0;
+            --kc-text-muted:  #a0aec0;
+            --kc-header-bg:   #252540;
+            --kc-link:        #e2e8f0;
+        }
+    }
+
+    .kamva-crud-wrap[data-kc-dark="dark"] {
+        --kc-bg:          #0f0f1a;
+        --kc-surface:     #1c1c2e;
+        --kc-card-bg:     #1e1e30;
+        --kc-card-border: rgba(255, 255, 255, 0.08);
+        --kc-text:        #e2e8f0;
+        --kc-text-muted:  #a0aec0;
+        --kc-header-bg:   #252540;
+        --kc-link:        #e2e8f0;
+    }
+
+    /* Kanban board */
+    .kamva-crud-wrap .kamva-kanban-col {
+        background: var(--kc-surface) !important;
+        color: var(--kc-text);
+    }
+    .kamva-crud-wrap .kamva-kanban-card {
+        background: var(--kc-card-bg) !important;
+        border-color: var(--kc-card-border) !important;
+        color: var(--kc-text);
+    }
+    .kamva-crud-wrap .kamva-kanban-card a {
+        color: var(--kc-link);
+    }
+    .kamva-crud-wrap .kamva-kanban-card .kc-muted {
+        color: var(--kc-text-muted);
+    }
+
+    /* Bootstrap card overrides for detail view */
+    .kamva-crud-wrap .card {
+        background-color: var(--kc-card-bg);
+        border-color: var(--kc-card-border);
+        color: var(--kc-text);
+    }
+    .kamva-crud-wrap .card-header {
+        background-color: var(--kc-header-bg);
+        border-color: var(--kc-card-border);
+        color: var(--kc-text);
+    }
+    .kamva-crud-wrap .text-muted {
+        color: var(--kc-text-muted) !important;
+    }
+    .kamva-crud-wrap .border-bottom {
+        border-color: var(--kc-card-border) !important;
+    }
+    .kamva-crud-wrap .alert-light {
+        background-color: var(--kc-surface);
+        border-color: var(--kc-card-border);
+        color: var(--kc-text);
+    }
+</style>

--- a/src/views/detail.blade.php
+++ b/src/views/detail.blade.php
@@ -12,7 +12,9 @@
 @extends('layouts.app')
 @section('title', $title)
 @section('content')
-<div class="container-fluid py-3">
+@include('kamva-crud::_dark_mode')
+@php $kcDark = \Kamva\Crud\KamvaCrud::getDarkMode(); @endphp
+<div class="kamva-crud-wrap container-fluid py-3"{{ $kcDark !== 'auto' ? ' data-kc-dark="'.e($kcDark).'"' : '' }}>
     <div class="d-flex justify-content-between align-items-center mb-3">
         <h4 class="mb-0">{{ $title }}</h4>
         <div>

--- a/src/views/kanban.blade.php
+++ b/src/views/kanban.blade.php
@@ -17,7 +17,9 @@
 @extends('layouts.app')
 @section('title', $title)
 @section('content')
-<div class="container-fluid py-3">
+@include('kamva-crud::_dark_mode')
+@php $kcDark = \Kamva\Crud\KamvaCrud::getDarkMode(); @endphp
+<div class="kamva-crud-wrap container-fluid py-3"{{ $kcDark !== 'auto' ? ' data-kc-dark="'.e($kcDark).'"' : '' }}>
 
     <div class="d-flex justify-content-between align-items-center mb-3">
         <h4 class="mb-0">{{ $title }}</h4>
@@ -53,7 +55,7 @@
                 $color = $def['color'] ?? 'secondary';
                 $acceptsDrop = $def['accepts_drop'] ?? true;
             @endphp
-            <div class="kamva-kanban-col" style="flex:0 0 240px;max-width:240px;background:#f4f5f7;border-radius:6px;padding:8px;">
+            <div class="kamva-kanban-col" style="flex:0 0 240px;max-width:240px;border-radius:6px;padding:8px;">
                 <div class="kamva-kanban-col-header d-flex justify-content-between align-items-center mb-2 px-1">
                     <span class="font-weight-bold">{{ $def['label'] ?? $col['key'] }}</span>
                     <small class="text-muted">
@@ -66,7 +68,7 @@
                 <div class="kamva-kanban-col-body" data-stage="{{ $col['key'] }}" data-accepts-drop="{{ $acceptsDrop ? '1' : '0' }}" style="min-height:80px;">
                     @foreach ($col['cards'] as $card)
                         <div class="kamva-kanban-card" data-id="{{ $card['id'] ?? '' }}"
-                             style="background:#fff;border:1px solid rgba(0,0,0,0.08);border-radius:4px;padding:8px 10px;margin-bottom:8px;cursor:grab;font-size:0.875rem;">
+                             style="border:1px solid;border-radius:4px;padding:8px 10px;margin-bottom:8px;cursor:grab;font-size:0.875rem;">
                             @if (!empty($card['href']))
                                 <a href="{{ $card['href'] }}" draggable="false" style="color:inherit;text-decoration:none;display:block;">
                             @endif
@@ -74,10 +76,10 @@
                                     <div style="font-weight:600;margin-bottom:2px;">{{ $card['title'] }}</div>
                                 @endif
                                 @if (!empty($card['subtitle']))
-                                    <div class="text-truncate" style="font-size:0.75rem;color:#718096;">{{ $card['subtitle'] }}</div>
+                                    <div class="text-truncate kc-muted" style="font-size:0.75rem;">{{ $card['subtitle'] }}</div>
                                 @endif
                                 @if (!empty($card['body']))
-                                    <div style="font-size:0.75rem;color:#718096;margin-top:4px;">{{ $card['body'] }}</div>
+                                    <div class="kc-muted" style="font-size:0.75rem;margin-top:4px;">{{ $card['body'] }}</div>
                                 @endif
                                 @if (isset($card['value']) && $card['value'] !== null)
                                     <div style="font-size:0.75rem;font-weight:600;margin-top:6px;">{{ $card['value'] }}</div>


### PR DESCRIPTION
## Summary
Adds comprehensive dark mode support to the kamva-crud package views, allowing consuming applications to control theme preference via a new `setDarkMode()` service method.

## Key Changes

- **New dark mode stylesheet** (`src/views/_dark_mode.blade.php`):
  - Defines CSS custom properties for light and dark themes
  - Supports three modes: `'auto'` (system preference), `'dark'` (forced dark), `'light'` (forced light)
  - Includes styles for kanban board, cards, headers, borders, and alerts
  - Uses `data-kc-dark` attribute to override system preference when needed

- **Service API** (`src/Service.php`):
  - Added `setDarkMode(string $mode = 'auto'): void` to configure theme preference
  - Added `getDarkMode(): string` to retrieve current setting
  - Defaults to `'auto'` for system-respecting behavior

- **View updates** (`src/views/kanban.blade.php`, `src/views/detail.blade.php`):
  - Include the dark mode stylesheet
  - Wrap content in `kamva-crud-wrap` container with optional `data-kc-dark` attribute
  - Removed hardcoded colors from kanban cards and columns (now use CSS variables)
  - Applied `kc-muted` class to subtitle/body text for consistent dark mode styling

## Implementation Details

- Dark mode uses CSS custom properties (`--kc-*`) for easy theming
- Media query `prefers-color-scheme: dark` automatically applies dark theme when system preference is dark (in `'auto'` mode)
- The `data-kc-dark` attribute on the wrapper element allows explicit override of system preference
- All color values are defined in the stylesheet, making future theme customization straightforward

https://claude.ai/code/session_012uwrNmxxkPdBdR8JQCZVwS